### PR TITLE
Move cursor inside BTree

### DIFF
--- a/benches/sequential.rs
+++ b/benches/sequential.rs
@@ -1,71 +1,62 @@
-use criterion::criterion_main;
+use std::time::Duration;
+
+use criterion::{criterion_main, SamplingMode};
 
 mod util;
 
 use cds::{avltree::AVLTree, btree::BTree};
 use criterion::{criterion_group, Criterion};
-use util::sequential::{bench_mixed_sequential_map, bench_sequential_map};
+use util::sequential::{bench_sequential_map, fuzz_sequential_logs};
+
+use crate::util::sequential::{bench_logs_btreemap, bench_logs_sequential_map};
 
 const MAP_ALREADY_INSERTED: u64 = 500_000;
 const MAP_TOTAL_OPS: usize = 500_000;
-const MAP_INSERT_RATE: usize = 30;
-const MAP_LOOKUP_RATE: usize = 50;
-const MAP_REMOVE_RATE: usize = 20;
 
 fn bench_btreemap(c: &mut Criterion) {
     util::sequential::bench_btreemap(1_000_000, c);
-}
-
-fn bench_mixed_btreemap(c: &mut Criterion) {
-    assert_eq!(MAP_INSERT_RATE + MAP_LOOKUP_RATE + MAP_REMOVE_RATE, 100);
-
-    util::sequential::bench_mixed_btreemap(
-        MAP_ALREADY_INSERTED,
-        MAP_TOTAL_OPS * MAP_INSERT_RATE / 100,
-        MAP_TOTAL_OPS * MAP_LOOKUP_RATE / 100,
-        MAP_TOTAL_OPS * MAP_REMOVE_RATE / 100,
-        c,
-    );
 }
 
 fn bench_avltree(c: &mut Criterion) {
     bench_sequential_map::<AVLTree<_, _>>("AVLTree", 1_000_000, c);
 }
 
-fn bench_mixed_avltree(c: &mut Criterion) {
-    bench_mixed_sequential_map::<AVLTree<_, _>>(
-        "AVLTree",
-        MAP_ALREADY_INSERTED,
-        MAP_TOTAL_OPS * MAP_INSERT_RATE / 100,
-        MAP_TOTAL_OPS * MAP_LOOKUP_RATE / 100,
-        MAP_TOTAL_OPS * MAP_REMOVE_RATE / 100,
-        c,
-    );
-}
-
 fn bench_btree(c: &mut Criterion) {
     bench_sequential_map::<BTree<_, _>>("BTree", 1_000_000, c);
 }
 
-fn bench_mixed_btree(c: &mut Criterion) {
-    bench_mixed_sequential_map::<BTree<_, _>>(
-        "BTree",
-        MAP_ALREADY_INSERTED,
-        MAP_TOTAL_OPS * MAP_INSERT_RATE / 100,
-        MAP_TOTAL_OPS * MAP_LOOKUP_RATE / 100,
-        MAP_TOTAL_OPS * MAP_REMOVE_RATE / 100,
-        c,
-    );
+fn bench_btree_vs_btreemap(c: &mut Criterion) {
+    let ops_rate = [(10, 80, 10), (20, 40, 20), (30, 50, 20), (40, 20, 40)];
+
+    for (insert, lookup, remove) in ops_rate {
+        println!("Creating logs...");
+        let logs = fuzz_sequential_logs(
+            200,
+            MAP_ALREADY_INSERTED,
+            MAP_TOTAL_OPS * insert / 100,
+            MAP_TOTAL_OPS * lookup / 100,
+            MAP_TOTAL_OPS * remove / 100,
+        );
+
+        let mut group = c.benchmark_group(format!(
+            "std::BTreeMap vs BTree: Inserted {:+e}, Ops (I: {}%, L: {}%, R: {}%, total: {:+e})",
+            MAP_ALREADY_INSERTED, insert, lookup, remove, MAP_TOTAL_OPS
+        ));
+        group.measurement_time(Duration::from_secs(15)); // Note: make almost same the measurement_time to iters * avg_op_time
+        group.sampling_mode(SamplingMode::Flat);
+        group.sample_size(20);
+
+        bench_logs_btreemap(logs.clone(), &mut group);
+        bench_logs_sequential_map::<BTree<_, _>>("BTree", logs, &mut group);
+    }
 }
 
 criterion_group!(
     bench,
     bench_btreemap,
-    bench_mixed_btreemap,
     bench_avltree,
-    bench_mixed_avltree,
     bench_btree,
-    bench_mixed_btree,
+    bench_btree_vs_btreemap
 );
 criterion_main! {
     bench,

--- a/benches/util/sequential.rs
+++ b/benches/util/sequential.rs
@@ -4,8 +4,50 @@ use std::{
 };
 
 use cds::map::SequentialMap;
-use criterion::{black_box, Criterion};
+use criterion::{black_box, measurement::WallTime, BenchmarkGroup, Criterion};
 use rand::{prelude::SliceRandom, thread_rng, Rng};
+
+#[derive(Clone, Copy)]
+pub enum Op {
+    Insert(u64),
+    Lookup(u64),
+    Remove(u64),
+}
+
+pub fn fuzz_sequential_logs(
+    iters: u64,
+    already_inserted: u64,
+    insert: usize,
+    lookup: usize,
+    remove: usize,
+) -> Vec<(Vec<u64>, Vec<Op>)> {
+    let mut rng = thread_rng();
+    let mut result = Vec::new();
+
+    for _ in 0..iters {
+        let mut logs = Vec::new();
+
+        let mut pre_inserted: Vec<u64> = (0..already_inserted).collect();
+        pre_inserted.shuffle(&mut rng);
+
+        for _ in 0..insert {
+            logs.push(Op::Insert(rng.gen_range(already_inserted..u64::MAX)));
+        }
+
+        for _ in 0..lookup {
+            logs.push(Op::Lookup(rng.gen_range(0..already_inserted)));
+        }
+
+        for _ in 0..remove {
+            logs.push(Op::Remove(rng.gen_range(0..already_inserted)));
+        }
+
+        logs.shuffle(&mut rng);
+        result.push((pre_inserted, logs));
+    }
+
+    result
+}
 
 pub fn bench_btreemap(already_inserted: u64, c: &mut Criterion) {
     c.bench_function(
@@ -123,72 +165,40 @@ pub fn bench_btreemap(already_inserted: u64, c: &mut Criterion) {
     );
 }
 
-pub fn bench_mixed_btreemap(
-    already_inserted: u64,
-    insert: usize,
-    lookup: usize,
-    remove: usize,
-    c: &mut Criterion,
-) {
-    let total_ops = insert + lookup + remove;
+pub fn bench_logs_btreemap(mut logs: Vec<(Vec<u64>, Vec<Op>)>, c: &mut BenchmarkGroup<WallTime>) {
+    c.bench_function("std::BTreeMap", |b| {
+        b.iter_custom(|iters| {
+            let mut duration = Duration::ZERO;
 
-    c.bench_function(
-        &format!(
-            "Inserted {:+e} std::BTreeMap Ops (I: {}%, L: {}%, R: {}%, total: {:+e})",
-            already_inserted,
-            insert * 100 / total_ops,
-            lookup * 100 / total_ops,
-            remove * 100 / total_ops,
-            total_ops,
-        ),
-        |b| {
-            b.iter_custom(|iters| {
-                let total_ops = insert + lookup + remove;
-
+            for _ in 0..iters {
+                let (pre_inserted, logs) = logs.pop().unwrap();
                 let mut map = BTreeMap::new();
-                let mut rng = thread_rng();
-
-                let mut range: Vec<u64> = (0..already_inserted).collect();
-                range.shuffle(&mut rng);
 
                 // pre-insert
-                for i in range {
-                    let _ = map.insert(i, i);
+                for key in pre_inserted {
+                    let _ = map.insert(key, key);
                 }
 
-                let mut duration = Duration::ZERO;
-                for _ in 0..iters {
-                    let mut rng = thread_rng();
-
-                    for _ in 0..total_ops {
-                        let op_idx = rng.gen_range(0..total_ops);
-
-                        if op_idx < insert {
-                            let key: u64 = rng.gen_range(already_inserted..u64::MAX);
-
-                            let start = Instant::now();
+                let start = Instant::now();
+                for op in logs {
+                    match op {
+                        Op::Insert(key) => {
                             let _ = black_box(map.insert(key, key));
-                            duration += start.elapsed();
-                        } else if op_idx < insert + lookup {
-                            let key: u64 = rng.gen_range(0..already_inserted);
-
-                            let start = Instant::now();
+                        }
+                        Op::Lookup(key) => {
                             let _ = black_box(map.get(&key));
-                            duration += start.elapsed();
-                        } else {
-                            let key: u64 = rng.gen_range(0..already_inserted);
-
-                            let start = Instant::now();
+                        }
+                        Op::Remove(key) => {
                             let _ = black_box(map.remove(&key));
-                            duration += start.elapsed();
                         }
                     }
                 }
+                duration += start.elapsed();
+            }
 
-                duration
-            });
-        },
-    );
+            duration
+        });
+    });
 }
 
 pub fn bench_sequential_map<M>(name: &str, already_inserted: u64, c: &mut Criterion)
@@ -196,7 +206,10 @@ where
     M: SequentialMap<u64, u64>,
 {
     c.bench_function(
-        &format!("Inserted {:+e} {} Insert (batch: 100)", already_inserted, name),
+        &format!(
+            "Inserted {:+e} {} Insert (batch: 100)",
+            already_inserted, name
+        ),
         |b| {
             b.iter_custom(|iters| {
                 let mut map = M::new();
@@ -270,7 +283,10 @@ where
     );
 
     c.bench_function(
-        &format!("Inserted {:+e} {} Remove (batch: 100)", already_inserted, name),
+        &format!(
+            "Inserted {:+e} {} Remove (batch: 100)",
+            already_inserted, name
+        ),
         |b| {
             b.iter_custom(|iters| {
                 let mut map = M::new();
@@ -303,74 +319,44 @@ where
     );
 }
 
-pub fn bench_mixed_sequential_map<M>(
+pub fn bench_logs_sequential_map<M>(
     name: &str,
-    already_inserted: u64,
-    insert: usize,
-    lookup: usize,
-    remove: usize,
-    c: &mut Criterion,
+    mut logs: Vec<(Vec<u64>, Vec<Op>)>,
+    c: &mut BenchmarkGroup<WallTime>,
 ) where
     M: SequentialMap<u64, u64>,
 {
-    let total_ops = insert + lookup + remove;
+    c.bench_function(name, |b| {
+        b.iter_custom(|iters| {
+            let mut duration = Duration::ZERO;
 
-    c.bench_function(
-        &format!(
-            "Inserted {:+e} {} Ops (I: {}%, L: {}%, R: {}%, total: {:+e})",
-            already_inserted,
-            name,
-            insert * 100 / total_ops,
-            lookup * 100 / total_ops,
-            remove * 100 / total_ops,
-            total_ops,
-        ),
-        |b| {
-            b.iter_custom(|iters| {
-                let total_ops = insert + lookup + remove;
-
+            for _ in 0..iters {
+                let (pre_inserted, logs) = logs.pop().unwrap();
                 let mut map = M::new();
-                let mut rng = thread_rng();
-
-                let mut range: Vec<u64> = (0..already_inserted).collect();
-                range.shuffle(&mut rng);
 
                 // pre-insert
-                for i in range {
-                    let _ = map.insert(&i, i);
+                for key in pre_inserted {
+                    let _ = map.insert(&key, key);
                 }
 
-                let mut duration = Duration::ZERO;
-                for _ in 0..iters {
-                    let mut rng = thread_rng();
-
-                    for _ in 0..total_ops {
-                        let op_idx = rng.gen_range(0..total_ops);
-
-                        if op_idx < insert {
-                            let key: u64 = rng.gen_range(already_inserted..u64::MAX);
-
-                            let start = Instant::now();
+                let start = Instant::now();
+                for op in logs {
+                    match op {
+                        Op::Insert(key) => {
                             let _ = black_box(map.insert(&key, key));
-                            duration += start.elapsed();
-                        } else if op_idx < insert + lookup {
-                            let key: u64 = rng.gen_range(0..already_inserted);
-
-                            let start = Instant::now();
+                        }
+                        Op::Lookup(key) => {
                             let _ = black_box(map.lookup(&key));
-                            duration += start.elapsed();
-                        } else {
-                            let key: u64 = rng.gen_range(0..already_inserted);
-
-                            let start = Instant::now();
+                        }
+                        Op::Remove(key) => {
                             let _ = black_box(map.remove(&key));
-                            duration += start.elapsed();
                         }
                     }
                 }
+                duration += start.elapsed();
+            }
 
-                duration
-            });
-        },
-    );
+            duration
+        });
+    });
 }


### PR DESCRIPTION
기존에는 Insert, Lookup, Remove를 위해서 helper의 일종인 `Cursor`를 매번 생성하고 사용했습니다. 이는, 반복적인 `Cursor`의 할당과 해제를 일으키기 때문에 상당히 비효율적입니다. 따라서, `RefCell`을 사용하여 `BTree` 안에 mutable한 `cursor`를 가질 수 있도록 구조를 바꾸고, 일부 코드 리팩토링 및 최적화를 진행했습니다. 