### PR TITLE
[SeqlockAVLTree] Optimize thoroughly

### DIFF
--- a/src/avltree/seqlock.rs
+++ b/src/avltree/seqlock.rs
@@ -645,7 +645,7 @@ where
             if cursor.dir == Dir::Eq {
                 let write_guard = ok_or!(cursor.inner_guard.clone().upgrade(), continue);
 
-                return unsafe { f(write_guard.value.load(Ordering::Acquire, guard).as_ref()) };
+                return unsafe { f(write_guard.value.load(Ordering::Relaxed, guard).as_ref()) };
             } else {
                 return f(None);
             }
@@ -670,7 +670,7 @@ where
                     cursor
                         .inner_guard
                         .value
-                        .load(Ordering::Acquire, guard)
+                        .load(Ordering::Relaxed, guard)
                         .as_ref()
                         .cloned()
                 };
@@ -704,7 +704,7 @@ where
 
             let value = write_guard
                 .value
-                .swap(Shared::null(), Ordering::Acquire, guard);
+                .swap(Shared::null(), Ordering::Relaxed, guard);
 
             if value.is_null() {
                 return Err(());

--- a/src/avltree/seqlock.rs
+++ b/src/avltree/seqlock.rs
@@ -3,7 +3,6 @@ use crossbeam_epoch::Atomic;
 use crossbeam_epoch::Guard;
 use crossbeam_epoch::Owned;
 use crossbeam_epoch::Shared;
-use crossbeam_utils::Backoff;
 use std::cmp::max;
 use std::fmt::Debug;
 use std::mem;
@@ -581,10 +580,7 @@ where
     fn insert(&self, key: &K, value: V, guard: &Guard) -> Result<(), V> {
         let mut cursor = Cursor::new(self, guard);
 
-        let backoff = Backoff::new();
         loop {
-            backoff.snooze();
-
             // if the cursor is invalid, then move up until cursor.inner_guard is valid
             cursor.recover();
             cursor.find(key, guard);
@@ -635,10 +631,7 @@ where
     {
         let mut cursor = Cursor::new(self, guard);
 
-        let backoff = Backoff::new();
         loop {
-            backoff.snooze();
-
             cursor.recover();
             cursor.find(key, guard);
 
@@ -658,10 +651,7 @@ where
     {
         let mut cursor = Cursor::new(self, guard);
 
-        let backoff = Backoff::new();
         loop {
-            backoff.snooze();
-
             cursor.recover();
             cursor.find(key, guard);
 
@@ -689,10 +679,7 @@ where
     fn remove(&self, key: &K, guard: &Guard) -> Result<V, ()> {
         let mut cursor = Cursor::new(self, guard);
 
-        let backoff = Backoff::new();
         loop {
-            backoff.snooze();
-
             cursor.recover();
             cursor.find(key, guard);
 

--- a/src/avltree/seqlock.rs
+++ b/src/avltree/seqlock.rs
@@ -547,6 +547,7 @@ impl<K, V> Drop for SeqLockAVLTree<K, V> {
 
 impl<K, V> SeqLockAVLTree<K, V> {
     /// get the height of the tree
+    /// Since using read lock without validation for lightweight, it cannot ensure the value.
     pub fn get_height(&self, guard: &Guard) -> usize {
         unsafe {
             if let Some(node) = self
@@ -555,7 +556,7 @@ impl<K, V> SeqLockAVLTree<K, V> {
                 .as_ref()
                 .unwrap()
                 .inner
-                .write_lock()
+                .read_lock()
                 .right
                 .load(Ordering::Acquire, guard)
                 .as_ref()

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,1 +1,21 @@
 pub mod random;
+
+#[macro_export]
+macro_rules! ok_or {
+    ($e:expr, $err:expr) => {{
+        match $e {
+            Ok(r) => r,
+            Err(_) => $err,
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! some_or {
+    ($e:expr, $err:expr) => {{
+        match $e {
+            Some(r) => r,
+            None => $err,
+        }
+    }};
+}


### PR DESCRIPTION
ARM 64코어 머신(AWS EC2: c6g.metal)에서 기존의 SeqLockAVLTree를 벤치마크해본 결과, 16코어 이상에서 많은 throughput 하락이 있었습니다. 이는 아마도 각 operation에서 실패할 경우 loop를 돌 때,  backoff가 없어서 생긴 contention으로 추정되기 때문에, 각 operation에 backoff를 추가해봤습니다.