### PR TITLE
Implement ART(Adaptive Radix Tree) on sequential

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ crossbeam-epoch = "0.9.5"
 crossbeam-utils = "0.8.5"
 rand = "0.8.4"
 either = "1.6.1"
+arr_macro = "0.1.3"
 
 [dev-dependencies]
 criterion = "0.3.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 crossbeam-epoch = "0.9.5"
 crossbeam-utils = "0.8.5"
 rand = "0.8.4"
+either = "1.6.1"
 
 [dev-dependencies]
 criterion = "0.3.4"

--- a/benches/util/sequential.rs
+++ b/benches/util/sequential.rs
@@ -3,43 +3,48 @@ use std::{
     time::{Duration, Instant},
 };
 
-use cds::map::SequentialMap;
+use cds::{map::SequentialMap, util::random::Random};
 use criterion::{black_box, measurement::WallTime, BenchmarkGroup};
-use rand::{prelude::SliceRandom, thread_rng, Rng};
+use rand::{prelude::SliceRandom, thread_rng};
 
 #[derive(Clone, Copy)]
-pub enum Op {
-    Insert(u64),
-    Lookup(u64),
-    Remove(u64),
+pub enum Op<K, V> {
+    Insert(K, V),
+    Lookup(K),
+    Remove(K),
 }
 
-pub fn fuzz_sequential_logs(
+type Logs<K, V> = Vec<(Vec<(K, V)>, Vec<Op<K, V>>)>;
+
+pub fn fuzz_sequential_logs<K: Ord + Random, V: Random>(
     iters: u64,
     already_inserted: u64,
     insert: usize,
     lookup: usize,
     remove: usize,
-) -> Vec<(Vec<u64>, Vec<Op>)> {
+) -> Logs<K, V> {
     let mut rng = thread_rng();
     let mut result = Vec::new();
 
     for _ in 0..iters {
         let mut logs = Vec::new();
 
-        let mut pre_inserted: Vec<u64> = (0..already_inserted).collect();
-        pre_inserted.shuffle(&mut rng);
+        let mut pre_inserted = Vec::new();
+
+        for _ in 0..already_inserted {
+            pre_inserted.push((K::gen(&mut rng), V::gen(&mut rng)));
+        }
 
         for _ in 0..insert {
-            logs.push(Op::Insert(rng.gen_range(already_inserted..u64::MAX)));
+            logs.push(Op::Insert(K::gen(&mut rng), V::gen(&mut rng)));
         }
 
         for _ in 0..lookup {
-            logs.push(Op::Lookup(rng.gen_range(0..already_inserted)));
+            logs.push(Op::Lookup(K::gen(&mut rng)));
         }
 
         for _ in 0..remove {
-            logs.push(Op::Remove(rng.gen_range(0..already_inserted)));
+            logs.push(Op::Remove(K::gen(&mut rng)));
         }
 
         logs.shuffle(&mut rng);
@@ -49,7 +54,7 @@ pub fn fuzz_sequential_logs(
     result
 }
 
-pub fn bench_logs_btreemap(mut logs: Vec<(Vec<u64>, Vec<Op>)>, c: &mut BenchmarkGroup<WallTime>) {
+pub fn bench_logs_btreemap<K: Ord, V>(mut logs: Logs<K, V>, c: &mut BenchmarkGroup<WallTime>) {
     c.bench_function("std::BTreeMap", |b| {
         b.iter_custom(|iters| {
             let mut duration = Duration::ZERO;
@@ -59,15 +64,15 @@ pub fn bench_logs_btreemap(mut logs: Vec<(Vec<u64>, Vec<Op>)>, c: &mut Benchmark
                 let mut map = BTreeMap::new();
 
                 // pre-insert
-                for key in pre_inserted {
-                    let _ = map.insert(key, key);
+                for (key, value) in pre_inserted {
+                    let _ = map.insert(key, value);
                 }
 
                 let start = Instant::now();
                 for op in logs {
                     match op {
-                        Op::Insert(key) => {
-                            let _ = black_box(map.insert(key, key));
+                        Op::Insert(key, value) => {
+                            let _ = black_box(map.insert(key, value));
                         }
                         Op::Lookup(key) => {
                             let _ = black_box(map.get(&key));
@@ -85,12 +90,13 @@ pub fn bench_logs_btreemap(mut logs: Vec<(Vec<u64>, Vec<Op>)>, c: &mut Benchmark
     });
 }
 
-pub fn bench_logs_sequential_map<M>(
+pub fn bench_logs_sequential_map<K, V, M>(
     name: &str,
-    mut logs: Vec<(Vec<u64>, Vec<Op>)>,
+    mut logs: Logs<K, V>,
     c: &mut BenchmarkGroup<WallTime>,
 ) where
-    M: SequentialMap<u64, u64>,
+    K: Eq + Random,
+    M: SequentialMap<K, V>,
 {
     c.bench_function(name, |b| {
         b.iter_custom(|iters| {
@@ -101,15 +107,15 @@ pub fn bench_logs_sequential_map<M>(
                 let mut map = M::new();
 
                 // pre-insert
-                for key in pre_inserted {
-                    let _ = map.insert(&key, key);
+                for (key, value) in pre_inserted {
+                    let _ = map.insert(&key, value);
                 }
 
                 let start = Instant::now();
                 for op in logs {
                     match op {
-                        Op::Insert(key) => {
-                            let _ = black_box(map.insert(&key, key));
+                        Op::Insert(key, value) => {
+                            let _ = black_box(map.insert(&key, value));
                         }
                         Op::Lookup(key) => {
                             let _ = black_box(map.lookup(&key));

--- a/src/art/mod.rs
+++ b/src/art/mod.rs
@@ -1229,7 +1229,7 @@ impl<K: Eq + Encodable, V: Debug> SequentialMap<K, V> for ART<K, V> {
                 Ok(())
             }
             Either::Right(nodev) => {
-                if depth == keys.len() {
+                if *nodev.key == keys {
                     return Err(value);
                 }
 
@@ -1238,8 +1238,6 @@ impl<K: Eq + Encodable, V: Debug> SequentialMap<K, V> for ART<K, V> {
                 // insert inter node with zero prefix
                 // ex) 'aE', 'aaE'
                 // println!("split with same index {}", keys[depth]);
-
-
                 let mut common_prefix = 0;
 
                 while keys[depth + common_prefix] == nodev.key[depth + common_prefix] {
@@ -1289,6 +1287,10 @@ impl<K: Eq + Encodable, V: Debug> SequentialMap<K, V> for ART<K, V> {
             let node = left_or!(current.deref(), break);
             depth += node.header().len as usize;
 
+            if depth >= keys.len() {
+                return None;
+            }
+
             if let Some(node) = node.lookup(keys[depth]) {
                 depth += 1;
                 current = node;
@@ -1320,6 +1322,10 @@ impl<K: Eq + Encodable, V: Debug> SequentialMap<K, V> for ART<K, V> {
             let current_ref = unsafe { current.as_mut() };
             let node = current_ref.deref_mut().unwrap_left();
             depth += node.header().len as usize;
+
+            if depth >= keys.len() {
+                return Err(());
+            }
 
             if let Some(node) = node.lookup_mut(keys[depth]) {
                 // println!("{:?}, key: {}, {}", node, keys[depth], depth);

--- a/src/art/mod.rs
+++ b/src/art/mod.rs
@@ -1,0 +1,112 @@
+use std::{
+    marker::PhantomData,
+    mem,
+};
+
+use either::Either;
+
+use crate::map::SequentialMap;
+
+struct NodeHeader {
+    len: u8,          // the len of prefix
+    prefix: [u8; 15], // prefix for path compression
+}
+
+/// the child node type
+/// This is used for bitflag on child pointer.
+const NODETYPE_MASK: usize = 0b111;
+#[repr(usize)]
+enum NodeType {
+    Value = 0b000,
+    Node4 = 0b001,
+    Node16 = 0b010,
+    Node48 = 0b011,
+    Node256 = 0b100,
+}
+
+trait NodeOps<V> {
+    fn insert(&mut self, key: u8, node: Node<V>);
+    fn lookup(&self, key: u8) -> &Node<V>;
+    fn remove(&mut self, key: u8) -> Node<V>;
+}
+
+/// the pointer struct for Nodes or value
+struct Node<V> {
+    pointer: usize,
+    _marker: PhantomData<Box<V>>,
+}
+
+impl<V> Node<V> {
+    fn deref(&self) -> Either<&dyn NodeOps<V>, &V> {
+        unsafe {
+            let pointer = self.pointer & !NODETYPE_MASK;
+            let tag = mem::transmute(self.pointer & NODETYPE_MASK);
+
+            match tag {
+                NodeType::Value => Either::Right(&*(pointer as *const V)),
+                NodeType::Node4 => Either::Left(&*(pointer as *const Node4<V>)),
+                NodeType::Node16 => Either::Left(&*(pointer as *const Node16<V>)),
+                NodeType::Node48 => Either::Left(&*(pointer as *const Node48<V>)),
+                NodeType::Node256 => Either::Left(&*(pointer as *const Node256<V>)),
+            }
+        }
+    }
+}
+
+struct Node4<V> {
+    header: NodeHeader,
+    keys: [u8; 4],
+    children: [Node<V>; 4],
+}
+
+impl<V> NodeOps<V> for Node4<V> {}
+
+struct Node16<V> {
+    header: NodeHeader,
+    keys: [u8; 16],
+    children: [Node<V>; 16],
+}
+
+impl<V> NodeOps<V> for Node16<V> {}
+
+struct Node48<V> {
+    header: NodeHeader,
+    keys: [u8; 256],
+    children: [Node<V>; 48],
+}
+
+impl<V> NodeOps<V> for Node48<V> {}
+
+struct Node256<V> {
+    header: NodeHeader,
+    children: [Node<V>; 256],
+}
+
+impl<V> NodeOps<V> for Node256<V> {}
+
+pub struct ART<K, V> {
+    root: Box<Node<V>>,
+    _marker: PhantomData<K>,
+}
+
+impl<K, V> ART<K, V> {
+
+}
+
+impl<K: Eq, V> SequentialMap<K, V> for ART<K, V> {
+    fn new() -> Self {
+        todo!()
+    }
+
+    fn insert(&mut self, key: &K, value: V) -> Result<(), V> {
+        todo!()
+    }
+
+    fn lookup(&self, key: &K) -> Option<&V> {
+        todo!()
+    }
+
+    fn remove(&mut self, key: &K) -> Result<V, ()> {
+        todo!()
+    }
+}

--- a/src/art/mod.rs
+++ b/src/art/mod.rs
@@ -1,7 +1,4 @@
-use std::{
-    marker::PhantomData,
-    mem,
-};
+use std::{iter::Peekable, marker::PhantomData, mem, ptr::NonNull};
 
 use either::Either;
 
@@ -84,8 +81,17 @@ struct Node256<V> {
 
 impl<V> NodeOps<V> for Node256<V> {}
 
+trait Encodable {
+    fn encode(self) -> Vec<u8>;
+}
+
+struct Cursor<V> {
+    parent: Option<NonNull<Node<V>>>,
+    current: NonNull<Node<V>>,
+}
+
 pub struct ART<K, V> {
-    root: Box<Node<V>>,
+    root: NonNull<Node<V>>,
     _marker: PhantomData<K>,
 }
 

--- a/src/art/mod.rs
+++ b/src/art/mod.rs
@@ -1,12 +1,29 @@
-use std::{iter::Peekable, marker::PhantomData, mem, ptr::NonNull};
+use std::{
+    cmp::Ordering,
+    marker::PhantomData,
+    mem,
+    ptr::{self, NonNull},
+};
 
 use either::Either;
 
-use crate::map::SequentialMap;
+use crate::{map::SequentialMap, util::slice_insert};
 
 struct NodeHeader {
-    len: u8,          // the len of prefix
-    prefix: [u8; 15], // prefix for path compression
+    len: u32,         // the len of prefix
+    prefix: [u8; 12], // prefix for path compression
+}
+
+impl Default for NodeHeader {
+    #[allow(deprecated)]
+    fn default() -> Self {
+        unsafe {
+            Self {
+                len: 0,
+                prefix: mem::uninitialized(),
+            }
+        }
+    }
 }
 
 /// the child node type
@@ -22,9 +39,12 @@ enum NodeType {
 }
 
 trait NodeOps<V> {
-    fn insert(&mut self, key: u8, node: Node<V>);
-    fn lookup(&self, key: u8) -> &Node<V>;
-    fn remove(&mut self, key: u8) -> Node<V>;
+    fn is_full(&self) -> bool;
+    fn is_shrinkable(&self) -> bool;
+    fn insert(&mut self, key: u8, node: Node<V>) -> Result<(), Node<V>>;
+    fn lookup(&self, key: u8) -> Option<&Node<V>>;
+    fn update(&mut self, key: u8, node: Node<V>) -> Result<Node<V>, Node<V>>;
+    fn remove(&mut self, key: u8) -> Result<Node<V>, ()>;
 }
 
 /// the pointer struct for Nodes or value
@@ -34,13 +54,13 @@ struct Node<V> {
 }
 
 impl<V> Node<V> {
-    fn deref(&self) -> Either<&dyn NodeOps<V>, &V> {
+    fn deref(&self) -> Either<&dyn NodeOps<V>, &NodeV<V>> {
         unsafe {
             let pointer = self.pointer & !NODETYPE_MASK;
             let tag = mem::transmute(self.pointer & NODETYPE_MASK);
 
             match tag {
-                NodeType::Value => Either::Right(&*(pointer as *const V)),
+                NodeType::Value => Either::Right(&*(pointer as *const NodeV<V>)),
                 NodeType::Node4 => Either::Left(&*(pointer as *const Node4<V>)),
                 NodeType::Node16 => Either::Left(&*(pointer as *const Node16<V>)),
                 NodeType::Node48 => Either::Left(&*(pointer as *const Node48<V>)),
@@ -48,38 +68,408 @@ impl<V> Node<V> {
             }
         }
     }
+
+    fn deref_mut(&mut self) -> Either<&mut dyn NodeOps<V>, &mut NodeV<V>> {
+        unsafe {
+            let pointer = self.pointer & !NODETYPE_MASK;
+            let tag = mem::transmute(self.pointer & NODETYPE_MASK);
+
+            match tag {
+                NodeType::Value => Either::Right(&mut *(pointer as *mut NodeV<V>)),
+                NodeType::Node4 => Either::Left(&mut *(pointer as *mut Node4<V>)),
+                NodeType::Node16 => Either::Left(&mut *(pointer as *mut Node16<V>)),
+                NodeType::Node48 => Either::Left(&mut *(pointer as *mut Node48<V>)),
+                NodeType::Node256 => Either::Left(&mut *(pointer as *mut Node256<V>)),
+            }
+        }
+    }
+
+    fn new(node: impl NodeOps<V>, node_type: NodeType) -> Self {
+        let node = Box::into_raw(Box::new(node));
+
+        Self {
+            pointer: node as usize | node_type as usize,
+            _marker: PhantomData,
+        }
+    }
+
+    const fn null() -> Self {
+        Self {
+            pointer: 0,
+            _marker: PhantomData,
+        }
+    }
+
+    #[inline]
+    fn is_null(&self) -> bool {
+        self.pointer == 0
+    }
+
+    fn node_type(&self) -> NodeType {
+        unsafe { mem::transmute(self.pointer & NODETYPE_MASK) }
+    }
+
+    /// extend node to bigger one only if necessary
+    fn extend(&mut self) {}
+
+    /// shrink node to smaller one only if necessary
+    fn shrink(&mut self) {}
+}
+
+struct NodeV<V> {
+    key: Box<[u8]>,
+    value: V,
 }
 
 struct Node4<V> {
     header: NodeHeader,
+    len: usize,
     keys: [u8; 4],
     children: [Node<V>; 4],
 }
 
-impl<V> NodeOps<V> for Node4<V> {}
+impl<V> Default for Node4<V> {
+    #[allow(deprecated)]
+    fn default() -> Self {
+        unsafe {
+            Self {
+                header: Default::default(),
+                len: 0,
+                keys: mem::uninitialized(),
+                children: mem::uninitialized(),
+            }
+        }
+    }
+}
+
+impl<V> Node4<V> {
+    fn keys(&self) -> &[u8] {
+        unsafe { self.keys.get_unchecked(..self.len as usize) }
+    }
+
+    fn mut_keys(&mut self) -> &mut [u8] {
+        unsafe { self.keys.get_unchecked_mut(..self.len as usize) }
+    }
+
+    fn children(&self) -> &[Node<V>] {
+        unsafe { self.children.get_unchecked(..self.len as usize) }
+    }
+
+    fn mut_children(&mut self) -> &mut [Node<V>] {
+        unsafe { self.children.get_unchecked_mut(..self.len as usize) }
+    }
+}
+
+impl<V> NodeOps<V> for Node4<V> {
+    #[inline]
+    fn is_full(&self) -> bool {
+        self.len == 4
+    }
+
+    #[inline]
+    fn is_shrinkable(&self) -> bool {
+        false
+    }
+
+    fn insert(&mut self, key: u8, node: Node<V>) -> Result<(), Node<V>> {
+        // since the &mut self is the pointer of Node4<V>, not the pointer of Node<V>,
+        // simple extension like this is impossble.
+        // if self.len == 4 {
+        //     unsafe {
+        //         let pointer = self as *const Node4<V> as *mut Node<V>;
+        //         let extended = Node::new(
+        //             Node16::from(ptr::read(pointer as *const Node4<V>)),
+        //             NodeType::Node16,
+        //         );
+        //         *(pointer as *mut Node<V>) = extended;
+        //         return (*pointer).deref_mut().left().unwrap().insert(key, node);
+        //     }
+        // }
+
+        for (index, k) in self.keys().iter().enumerate() {
+            match key.cmp(k) {
+                Ordering::Less => unsafe {
+                    self.len += 1;
+                    slice_insert(self.mut_keys(), index, key);
+                    slice_insert(self.mut_children(), index, node);
+                    return Ok(());
+                },
+                Ordering::Equal => return Err(node),
+                Ordering::Greater => {}
+            }
+        }
+
+        Err(node)
+    }
+
+    fn lookup(&self, key: u8) -> Option<&Node<V>> {
+        for (index, k) in self.keys().iter().enumerate() {
+            if key == *k {
+                return unsafe { Some(self.children.get_unchecked(index)) };
+            }
+        }
+
+        None
+    }
+
+    fn update(&mut self, key: u8, node: Node<V>) -> Result<Node<V>, Node<V>> {
+        for (index, k) in self.keys().iter().enumerate() {
+            match key.cmp(k) {
+                Ordering::Less => {}
+                Ordering::Equal => unsafe {
+                    let node = mem::replace(self.children.get_unchecked_mut(index), node);
+                    return Ok(node);
+                },
+                Ordering::Greater => {}
+            }
+        }
+
+        Err(node)
+    }
+
+    fn remove(&mut self, key: u8) -> Result<Node<V>, ()> {
+        todo!()
+    }
+}
 
 struct Node16<V> {
     header: NodeHeader,
+    len: usize,
     keys: [u8; 16],
     children: [Node<V>; 16],
 }
 
-impl<V> NodeOps<V> for Node16<V> {}
+impl<V> Default for Node16<V> {
+    #[allow(deprecated)]
+    fn default() -> Self {
+        unsafe {
+            Self {
+                header: Default::default(),
+                len: 0,
+                keys: mem::uninitialized(),
+                children: mem::uninitialized(),
+            }
+        }
+    }
+}
+
+impl<V> Node16<V> {
+    fn keys(&self) -> &[u8] {
+        unsafe { self.keys.get_unchecked(..self.len as usize) }
+    }
+
+    fn mut_keys(&mut self) -> &mut [u8] {
+        unsafe { self.keys.get_unchecked_mut(..self.len as usize) }
+    }
+
+    fn children(&self) -> &[Node<V>] {
+        unsafe { self.children.get_unchecked(..self.len as usize) }
+    }
+
+    fn mut_children(&mut self) -> &mut [Node<V>] {
+        unsafe { self.children.get_unchecked_mut(..self.len as usize) }
+    }
+
+    fn from(node: Node4<V>) -> Self {
+        let mut new = Self::default();
+        new.header = node.header;
+        new.len = node.len;
+
+        unsafe {
+            ptr::copy_nonoverlapping(node.keys.as_ptr(), new.keys.as_mut_ptr(), node.len as usize);
+            ptr::copy_nonoverlapping(
+                node.children.as_ptr(),
+                new.children.as_mut_ptr(),
+                node.len as usize,
+            );
+        }
+
+        new
+    }
+}
+
+impl<V> NodeOps<V> for Node16<V> {
+    #[inline]
+    fn is_full(&self) -> bool {
+        self.len == 16
+    }
+
+    #[inline]
+    fn is_shrinkable(&self) -> bool {
+        self.len <= 4
+    }
+
+    fn insert(&mut self, key: u8, node: Node<V>) -> Result<(), Node<V>> {
+        todo!()
+    }
+
+    fn lookup(&self, key: u8) -> Option<&Node<V>> {
+        todo!()
+    }
+
+    fn update(&mut self, key: u8, node: Node<V>) -> Result<Node<V>, Node<V>> {
+        todo!()
+    }
+
+    fn remove(&mut self, key: u8) -> Result<Node<V>, ()> {
+        todo!()
+    }
+}
 
 struct Node48<V> {
     header: NodeHeader,
+    len: usize,
     keys: [u8; 256],
     children: [Node<V>; 48],
 }
 
-impl<V> NodeOps<V> for Node48<V> {}
+impl<V> Default for Node48<V> {
+    #[allow(deprecated)]
+    fn default() -> Self {
+        unsafe {
+            Self {
+                header: Default::default(),
+                len: 0,
+                keys: mem::uninitialized(),
+                children: mem::uninitialized(),
+            }
+        }
+    }
+}
+
+impl<V> Node48<V> {
+    fn keys(&self) -> &[u8] {
+        unsafe { self.keys.get_unchecked(..self.len as usize) }
+    }
+
+    fn mut_keys(&mut self) -> &mut [u8] {
+        unsafe { self.keys.get_unchecked_mut(..self.len as usize) }
+    }
+
+    fn children(&self) -> &[Node<V>] {
+        unsafe { self.children.get_unchecked(..self.len as usize) }
+    }
+
+    fn mut_children(&mut self) -> &mut [Node<V>] {
+        unsafe { self.children.get_unchecked_mut(..self.len as usize) }
+    }
+
+    fn from(node: Node16<V>) -> Self {
+        let mut new = Self::default();
+
+        unsafe {
+            for (index, key) in node.keys().iter().enumerate() {
+                *new.keys.get_unchecked_mut(*key as usize) = index as u8;
+            }
+
+            ptr::copy_nonoverlapping(
+                node.children.as_ptr(),
+                new.children.as_mut_ptr(),
+                node.len as usize,
+            );
+        }
+
+        new.header = node.header;
+        new.len = node.len;
+
+        new
+    }
+}
+
+impl<V> NodeOps<V> for Node48<V> {
+    #[inline]
+    fn is_full(&self) -> bool {
+        self.len == 48
+    }
+
+    #[inline]
+    fn is_shrinkable(&self) -> bool {
+        self.len <= 16
+    }
+
+    fn insert(&mut self, key: u8, node: Node<V>) -> Result<(), Node<V>> {
+        todo!()
+    }
+
+    fn lookup(&self, key: u8) -> Option<&Node<V>> {
+        todo!()
+    }
+
+    fn update(&mut self, key: u8, node: Node<V>) -> Result<Node<V>, Node<V>> {
+        todo!()
+    }
+
+    fn remove(&mut self, key: u8) -> Result<Node<V>, ()> {
+        todo!()
+    }
+}
 
 struct Node256<V> {
     header: NodeHeader,
+    len: usize,
     children: [Node<V>; 256],
 }
 
-impl<V> NodeOps<V> for Node256<V> {}
+impl<V> Default for Node256<V> {
+    #[allow(deprecated)]
+    fn default() -> Self {
+        unsafe {
+            Self {
+                header: Default::default(),
+                len: 0,
+                children: mem::uninitialized(),
+            }
+        }
+    }
+}
+
+impl<V> Node256<V> {
+    fn from(node: Node48<V>) -> Self {
+        let mut new = Self::default();
+
+        unsafe {
+            for key in node.keys() {
+                *new.children.get_unchecked_mut(*key as usize) = ptr::read(
+                    node.children
+                        .get_unchecked(*node.keys.get_unchecked(*key as usize) as usize),
+                );
+            }
+        }
+
+        new.header = node.header;
+        new.len = node.len;
+
+        new
+    }
+}
+
+impl<V> NodeOps<V> for Node256<V> {
+    #[inline]
+    fn is_full(&self) -> bool {
+        self.len == 256
+    }
+
+    #[inline]
+    fn is_shrinkable(&self) -> bool {
+        self.len <= 48
+    }
+
+    fn insert(&mut self, key: u8, node: Node<V>) -> Result<(), Node<V>> {
+        todo!()
+    }
+
+    fn lookup(&self, key: u8) -> Option<&Node<V>> {
+        todo!()
+    }
+
+    fn update(&mut self, key: u8, node: Node<V>) -> Result<Node<V>, Node<V>> {
+        todo!()
+    }
+
+    fn remove(&mut self, key: u8) -> Result<Node<V>, ()> {
+        todo!()
+    }
+}
 
 trait Encodable {
     fn encode(self) -> Vec<u8>;
@@ -95,9 +485,7 @@ pub struct ART<K, V> {
     _marker: PhantomData<K>,
 }
 
-impl<K, V> ART<K, V> {
-
-}
+impl<K, V> ART<K, V> {}
 
 impl<K: Eq, V> SequentialMap<K, V> for ART<K, V> {
     fn new() -> Self {

--- a/src/btree/mod.rs
+++ b/src/btree/mod.rs
@@ -4,40 +4,10 @@ use std::ptr;
 use std::{cmp::Ordering, mem, ptr::NonNull};
 
 use crate::map::SequentialMap;
+use crate::util::{slice_insert, slice_remove};
 
 const B_MAX_NODES: usize = 11;
 const B_MID_INDEX: usize = B_MAX_NODES / 2;
-
-/// insert value into [T], which has one empty area on last.
-/// ex) insert C at 1 into [A, B, uninit] => [A, C, B]
-unsafe fn slice_insert<T>(ptr: &mut [T], index: usize, value: T) {
-    let size = ptr.len();
-    debug_assert!(size > index);
-
-    let ptr = ptr.as_mut_ptr();
-
-    if size > index + 1 {
-        ptr::copy(ptr.add(index), ptr.add(index + 1), size - index - 1);
-    }
-
-    ptr::write(ptr.add(index), value);
-}
-
-/// remove value from [T] and remain last area without any init
-/// ex) remove at 1 from [A, B, C] => [A, C, C(but you should not access here)]
-unsafe fn slice_remove<T>(ptr: &mut [T], index: usize) -> T {
-    let size = ptr.len();
-    debug_assert!(size > index);
-
-    let ptr = ptr.as_mut_ptr();
-    let value = ptr::read(ptr.add(index));
-
-    if size > index + 1 {
-        ptr::copy(ptr.add(index + 1), ptr.add(index), size - index - 1);
-    }
-
-    value
-}
 
 struct Node<K, V> {
     size: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod avltree;
 pub mod btree;
+pub mod art;
 pub mod linkedlist;
 mod lock;
 pub mod map;

--- a/src/linkedlist/mod.rs
+++ b/src/linkedlist/mod.rs
@@ -1,10 +1,12 @@
 use crate::map::SequentialMap;
 
 // simple sequential linked list
+#[derive(Debug)]
 pub struct LinkedList<K, V> {
     head: Node<K, V>, // dummy node with key = Default, but the key is not considered on algorithm
 }
 
+#[derive(Debug)]
 struct Node<K, V> {
     key: K,
     value: V,

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,4 +1,37 @@
+use std::ptr;
+
 pub mod random;
+
+/// insert value into [T], which has one empty area on last.
+/// ex) insert C at 1 into [A, B, uninit] => [A, C, B]
+pub unsafe fn slice_insert<T>(ptr: &mut [T], index: usize, value: T) {
+    let size = ptr.len();
+    debug_assert!(size > index);
+
+    let ptr = ptr.as_mut_ptr();
+
+    if size > index + 1 {
+        ptr::copy(ptr.add(index), ptr.add(index + 1), size - index - 1);
+    }
+
+    ptr::write(ptr.add(index), value);
+}
+
+/// remove value from [T] and remain last area without any init
+/// ex) remove at 1 from [A, B, C] => [A, C, C(but you should not access here)]
+pub unsafe fn slice_remove<T>(ptr: &mut [T], index: usize) -> T {
+    let size = ptr.len();
+    debug_assert!(size > index);
+
+    let ptr = ptr.as_mut_ptr();
+    let value = ptr::read(ptr.add(index));
+
+    if size > index + 1 {
+        ptr::copy(ptr.add(index + 1), ptr.add(index), size - index - 1);
+    }
+
+    value
+}
 
 #[macro_export]
 macro_rules! ok_or {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,4 +1,5 @@
 use std::ptr;
+use either::Either;
 
 pub mod random;
 
@@ -49,6 +50,16 @@ macro_rules! some_or {
         match $e {
             Some(r) => r,
             None => $err,
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! left_or {
+    ($e:expr, $err:expr) => {{
+        match $e {
+            Either::Left(l) => l,
+            Either::Right(_) => $err,
         }
     }};
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,5 +1,4 @@
 use std::ptr;
-use either::Either;
 
 pub mod random;
 

--- a/src/util/random.rs
+++ b/src/util/random.rs
@@ -6,7 +6,7 @@ pub trait Random {
 }
 
 const RANDOM_STRING_MIN: usize = 0;
-const RANDOM_STRING_MAX: usize = 10;
+const RANDOM_STRING_MAX: usize = 128;
 
 impl Random for String {
     // get random string whose length is in [RANDOM_STRING_MIN, RANDOM_STRING_MAX)

--- a/tests/art/mod.rs
+++ b/tests/art/mod.rs
@@ -1,0 +1,12 @@
+use cds::art::ART;
+use cds::map::SequentialMap;
+
+#[test]
+fn test_art() {
+    let mut art: ART<String, usize> = ART::new();
+
+    assert_eq!(art.insert(&"a".to_string(), 1), Ok(()));
+    assert_eq!(art.insert(&"aa".to_string(), 1), Ok(()));
+
+    println!("{:?}", art);
+}

--- a/tests/art/mod.rs
+++ b/tests/art/mod.rs
@@ -46,3 +46,28 @@ fn test_large_key_art() {
     assert_eq!(art.remove(&"12345678901234567890123456789012345678901234567890".to_string()), Ok(5));
     assert_eq!(art.remove(&"123456789012345678901234567890123456789012345678901234567890".to_string()), Ok(6));
 }
+
+#[test]
+fn test_split_key_insert_art() {
+    let mut art: ART<String, usize> = ART::new();
+    assert_eq!(art.insert(&"123456789012345678901234567890123456789012345678901234567890".to_string(), 6), Ok(()));
+    assert_eq!(art.insert(&"12345678901234567890123456789012345678901234567890".to_string(), 5), Ok(()));
+    assert_eq!(art.lookup(&"12345678901234567890123456789012345678901234567890".to_string()), Some(&5));
+    assert_eq!(art.lookup(&"123456789012345678901234567890123456789012345678901234567890".to_string()), Some(&6));
+    assert_eq!(art.insert(&"1234567890123456789012345678901234567890".to_string(), 4), Ok(()));
+    assert_eq!(art.insert(&"123456789012345678901234567890".to_string(), 3), Ok(()));
+    assert_eq!(art.insert(&"12345678901234567890".to_string(), 2), Ok(()));
+    assert_eq!(art.insert(&"1234567890".to_string(), 1), Ok(()));
+    assert_eq!(art.lookup(&"1234567890".to_string()), Some(&1));
+    assert_eq!(art.lookup(&"12345678901234567890".to_string()), Some(&2));
+    assert_eq!(art.lookup(&"123456789012345678901234567890".to_string()), Some(&3));
+    assert_eq!(art.lookup(&"1234567890123456789012345678901234567890".to_string()), Some(&4));
+    assert_eq!(art.lookup(&"12345678901234567890123456789012345678901234567890".to_string()), Some(&5));
+    assert_eq!(art.lookup(&"123456789012345678901234567890123456789012345678901234567890".to_string()), Some(&6));
+    assert_eq!(art.remove(&"123456789012345678901234567890123456789012345678901234567890".to_string()), Ok(6));
+    assert_eq!(art.remove(&"12345678901234567890123456789012345678901234567890".to_string()), Ok(5));
+    assert_eq!(art.remove(&"1234567890123456789012345678901234567890".to_string()), Ok(4));
+    assert_eq!(art.remove(&"123456789012345678901234567890".to_string()), Ok(3));
+    assert_eq!(art.remove(&"12345678901234567890".to_string()), Ok(2));
+    assert_eq!(art.remove(&"1234567890".to_string()), Ok(1));
+}

--- a/tests/art/mod.rs
+++ b/tests/art/mod.rs
@@ -76,10 +76,5 @@ fn test_split_key_insert_art() {
 
 #[test]
 fn stress_art() {
-    stress_sequential::<String, ART<_, _>>(100_000);
-}
-
-#[test]
-fn test_fuzz_case_art() {
-
+    stress_sequential::<String, ART<_, _>>(1_000_000);
 }

--- a/tests/art/mod.rs
+++ b/tests/art/mod.rs
@@ -23,3 +23,27 @@ fn test_art() {
     assert_eq!(art.remove(&"ad".to_string()), Ok(4));
     assert_eq!(art.remove(&"acb".to_string()), Ok(5));
 }
+
+#[test]
+fn test_large_key_art() {
+    let mut art: ART<String, usize> = ART::new();
+    assert_eq!(art.insert(&"1234567890".to_string(), 1), Ok(()));
+    assert_eq!(art.insert(&"12345678901234567890".to_string(), 2), Ok(()));
+    assert_eq!(art.insert(&"123456789012345678901234567890".to_string(), 3), Ok(()));
+    assert_eq!(art.insert(&"1234567890123456789012345678901234567890".to_string(), 4), Ok(()));
+    assert_eq!(art.insert(&"12345678901234567890123456789012345678901234567890".to_string(), 5), Ok(()));
+    assert_eq!(art.insert(&"123456789012345678901234567890123456789012345678901234567890".to_string(), 6), Ok(()));
+    assert_eq!(art.lookup(&"1234567890".to_string()), Some(&1));
+    assert_eq!(art.lookup(&"12345678901234567890".to_string()), Some(&2));
+    assert_eq!(art.lookup(&"123456789012345678901234567890".to_string()), Some(&3));
+    assert_eq!(art.lookup(&"1234567890123456789012345678901234567890".to_string()), Some(&4));
+    assert_eq!(art.lookup(&"12345678901234567890123456789012345678901234567890".to_string()), Some(&5));
+    assert_eq!(art.lookup(&"123456789012345678901234567890123456789012345678901234567890".to_string()), Some(&6));
+    assert_eq!(art.remove(&"1234567890".to_string()), Ok(1));
+    assert_eq!(art.remove(&"12345678901234567890".to_string()), Ok(2));
+    assert_eq!(art.remove(&"123456789012345678901234567890".to_string()), Ok(3));
+    assert_eq!(art.remove(&"1234567890123456789012345678901234567890".to_string()), Ok(4));
+    assert_eq!(art.remove(&"12345678901234567890123456789012345678901234567890".to_string()), Ok(5));
+    assert_eq!(art.remove(&"123456789012345678901234567890123456789012345678901234567890".to_string()), Ok(6));
+    println!("{:?}", art);
+}

--- a/tests/art/mod.rs
+++ b/tests/art/mod.rs
@@ -6,7 +6,14 @@ fn test_art() {
     let mut art: ART<String, usize> = ART::new();
 
     assert_eq!(art.insert(&"a".to_string(), 1), Ok(()));
-    assert_eq!(art.insert(&"aa".to_string(), 1), Ok(()));
+    assert_eq!(art.insert(&"ab".to_string(), 2), Ok(()));
+    assert_eq!(art.insert(&"ac".to_string(), 3), Ok(()));
+    assert_eq!(art.insert(&"ad".to_string(), 4), Ok(()));
+    assert_eq!(art.insert(&"acb".to_string(), 5), Ok(()));
 
-    println!("{:?}", art);
+    assert_eq!(art.lookup(&"a".to_string()), Some(&1));
+    assert_eq!(art.lookup(&"ab".to_string()),Some(&2));
+    assert_eq!(art.lookup(&"ac".to_string()),Some(&3));
+    assert_eq!(art.lookup(&"ad".to_string()),Some(&4));
+    assert_eq!(art.lookup(&"acb".to_string()),Some(&5));
 }

--- a/tests/art/mod.rs
+++ b/tests/art/mod.rs
@@ -1,5 +1,7 @@
 use cds::art::ART;
 use cds::map::SequentialMap;
+use rand::prelude::SliceRandom;
+use rand::thread_rng;
 
 use crate::util::map::stress_sequential;
 
@@ -27,6 +29,7 @@ fn test_art() {
 }
 
 #[test]
+#[rustfmt::skip]
 fn test_large_key_art() {
     let mut art: ART<String, usize> = ART::new();
     assert_eq!(art.insert(&"1234567890".to_string(), 1), Ok(()));
@@ -50,6 +53,7 @@ fn test_large_key_art() {
 }
 
 #[test]
+#[rustfmt::skip]
 fn test_split_key_insert_art() {
     let mut art: ART<String, usize> = ART::new();
     assert_eq!(art.insert(&"123456789012345678901234567890123456789012345678901234567890".to_string(), 6), Ok(()));
@@ -72,6 +76,41 @@ fn test_split_key_insert_art() {
     assert_eq!(art.remove(&"123456789012345678901234567890".to_string()), Ok(3));
     assert_eq!(art.remove(&"12345678901234567890".to_string()), Ok(2));
     assert_eq!(art.remove(&"1234567890".to_string()), Ok(1));
+}
+
+#[test]
+fn test_extend_shrink_art() {
+    let mut art: ART<String, usize> = ART::new();
+    let mut keys = Vec::new();
+
+    for i in '0'..'z' {
+        let key = "a".to_string() + &i.to_string();
+        assert_eq!(art.insert(&key, i as usize), Ok(()));
+        keys.push(key);
+
+        for k in &keys {
+            assert!(art.lookup(k).is_some(), "key: {:?}", k);
+        }
+    }
+
+    let mut rng = thread_rng();
+    keys.shuffle(&mut rng);
+
+    let mut removed_keys = Vec::new();
+
+    for _ in 0..keys.len() {
+        let key = keys.pop().unwrap();
+        assert!(art.remove(&key).is_ok());
+        removed_keys.push(key);
+
+        for k in &keys {
+            assert!(art.lookup(k).is_some(), "key: {:?}", k);
+        }
+
+        for k in &removed_keys {
+            assert!(art.lookup(k).is_none(), "key: {:?}", k);
+        }
+    }
 }
 
 #[test]

--- a/tests/art/mod.rs
+++ b/tests/art/mod.rs
@@ -12,8 +12,14 @@ fn test_art() {
     assert_eq!(art.insert(&"acb".to_string(), 5), Ok(()));
 
     assert_eq!(art.lookup(&"a".to_string()), Some(&1));
-    assert_eq!(art.lookup(&"ab".to_string()),Some(&2));
-    assert_eq!(art.lookup(&"ac".to_string()),Some(&3));
-    assert_eq!(art.lookup(&"ad".to_string()),Some(&4));
-    assert_eq!(art.lookup(&"acb".to_string()),Some(&5));
+    assert_eq!(art.lookup(&"ab".to_string()), Some(&2));
+    assert_eq!(art.lookup(&"ac".to_string()), Some(&3));
+    assert_eq!(art.lookup(&"ad".to_string()), Some(&4));
+    assert_eq!(art.lookup(&"acb".to_string()), Some(&5));
+
+    assert_eq!(art.remove(&"a".to_string()), Ok(1));
+    assert_eq!(art.remove(&"ab".to_string()), Ok(2));
+    assert_eq!(art.remove(&"ac".to_string()), Ok(3));
+    assert_eq!(art.remove(&"ad".to_string()), Ok(4));
+    assert_eq!(art.remove(&"acb".to_string()), Ok(5));
 }

--- a/tests/art/mod.rs
+++ b/tests/art/mod.rs
@@ -45,5 +45,4 @@ fn test_large_key_art() {
     assert_eq!(art.remove(&"1234567890123456789012345678901234567890".to_string()), Ok(4));
     assert_eq!(art.remove(&"12345678901234567890123456789012345678901234567890".to_string()), Ok(5));
     assert_eq!(art.remove(&"123456789012345678901234567890123456789012345678901234567890".to_string()), Ok(6));
-    println!("{:?}", art);
 }

--- a/tests/art/mod.rs
+++ b/tests/art/mod.rs
@@ -1,6 +1,8 @@
 use cds::art::ART;
 use cds::map::SequentialMap;
 
+use crate::util::map::stress_sequential;
+
 #[test]
 fn test_art() {
     let mut art: ART<String, usize> = ART::new();
@@ -70,4 +72,14 @@ fn test_split_key_insert_art() {
     assert_eq!(art.remove(&"123456789012345678901234567890".to_string()), Ok(3));
     assert_eq!(art.remove(&"12345678901234567890".to_string()), Ok(2));
     assert_eq!(art.remove(&"1234567890".to_string()), Ok(1));
+}
+
+#[test]
+fn stress_art() {
+    stress_sequential::<String, ART<_, _>>(100_000);
+}
+
+#[test]
+fn test_fuzz_case_art() {
+
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -7,6 +7,7 @@ use rand::{prelude::SliceRandom, thread_rng, Rng};
 
 mod avltree;
 mod btree;
+mod art;
 mod linkedlist;
 mod queue;
 mod stack;

--- a/tests/util/map.rs
+++ b/tests/util/map.rs
@@ -33,7 +33,7 @@ enum OperationType {
 pub fn stress_sequential<K, M>(iter: u64)
 where
     K: Ord + Clone + Random + Debug,
-    M: SequentialMap<K, u64>,
+    M: SequentialMap<K, u64> + Debug,
 {
     // 10 times try to get not existing key, or return if failing
     let gen_not_existing_key = |rng: &mut ThreadRng, map: &BTreeMap<K, u64>| {
@@ -121,6 +121,8 @@ where
                 }
                 Operation::Remove => {
                     // should success
+                    println!("{:?}", map);
+
                     let value = ref_map.remove(&existing_key);
 
                     println!(
@@ -132,15 +134,17 @@ where
                     assert_eq!(map.remove(&existing_key).ok(), value);
 
                     // early stop code if the remove has any problems
-                    // for key in ref_map.keys().collect::<Vec<&K>>() {
-                    //     assert_eq!(map.lookup(key).is_some(), true, "the key {:?} is not found.", key);
-                    // }
+                    println!("{:?}", map);
+                    for key in ref_map.keys().collect::<Vec<&K>>() {
+                        assert_eq!(map.lookup(key).is_some(), true, "the key {:?} is not found.", key);
+                    }
                 }
             }
         }
     }
 }
 
+#[derive(Debug)]
 struct Sequentialized<K, V, M>
 where
     K: Eq,
@@ -189,7 +193,7 @@ where
 pub fn stress_concurrent_as_sequential<K, M>(iter: u64)
 where
     K: Ord + Clone + Random + Debug,
-    M: ConcurrentMap<K, u64>,
+    M: ConcurrentMap<K, u64> + Debug,
 {
     stress_sequential::<K, Sequentialized<K, u64, M>>(iter)
 }

--- a/tests/util/map.rs
+++ b/tests/util/map.rs
@@ -58,6 +58,8 @@ where
     let mut rng = thread_rng();
 
     for i in 1..=iter {
+        let before = format!("{:?}", map);
+
         let t = types.choose(&mut rng).unwrap();
         let ref_map_keys = ref_map.keys().collect::<Vec<&K>>();
         let existing_key = ref_map_keys.choose(&mut rng);
@@ -121,8 +123,6 @@ where
                 }
                 Operation::Remove => {
                     // should success
-                    println!("{:?}", map);
-
                     let value = ref_map.remove(&existing_key);
 
                     println!(
@@ -132,13 +132,16 @@ where
                         value.unwrap()
                     );
                     assert_eq!(map.remove(&existing_key).ok(), value);
-
-                    // early stop code if the remove has any problems
-                    println!("{:?}", map);
-                    for key in ref_map.keys().collect::<Vec<&K>>() {
-                        assert_eq!(map.lookup(key).is_some(), true, "the key {:?} is not found.", key);
-                    }
                 }
+            }
+        }
+
+        // early stop code if the op has any problems
+        for key in ref_map.keys().collect::<Vec<&K>>() {
+            if map.lookup(key).is_none() {
+                println!("before: {}", before);
+                println!("after: {:?}", map);
+                panic!("the key {:?} is not found.", key);
             }
         }
     }


### PR DESCRIPTION
https://github.com/codingskynet/concurrent-data-structure/issues/10 에서 연구한, sequential에서 BTree보다 빠르고, HashMap보다도 우수한 캐시히트를 가지는 자료구조를 구현해봤습니다.
간략하게 PoC 정도로만 만들었기 때문에, PR 생성 이후 K를 무조건 String(for ascii)으로 고정시키고, Node256을 128로 바꾸는 패치 등을 진행해보는 것도 괜찮아 보입니다.